### PR TITLE
Hoisted SuperCommand.CrateSubCommand() into Command. Moved Command in…

### DIFF
--- a/cli/args_test.go
+++ b/cli/args_test.go
@@ -17,10 +17,10 @@ type SimpleCommand struct {
 	*clicmd.BaseCommand
 }
 
-func (cmd SimpleCommand) HandleArgs () error{ return nil }
-func (cmd SimpleCommand) Run () error { return nil }
+func (cmd SimpleCommand) HandleArgs() error { return nil }
+func (cmd SimpleCommand) Run() error        { return nil }
 
-func TestCommandArgs (t *testing.T) {
+func TestCommandArgs(t *testing.T) {
 	cmdline := clicmd.Cmdline{"foo", "bar", "bum"}
 	cmd := SimpleCommand{BaseCommand: &clicmd.BaseCommand{Cmdline: cmdline, FlagSet: &flag.FlagSet{}}}
 	err := cmd.Parse()
@@ -195,14 +195,14 @@ func (cmd *DaddyCommand) HandleArgs() error { return nil }
 func (cmd *DaddyCommand) Run() error        { return nil }
 
 func NewDaddyCommand(cmdline clicmd.Cmdline, parent *PappyCommand) *DaddyCommand {
-	return &DaddyCommand{BaseCommand: &clicmd.BaseCommand{Cmdline: cmdline, FlagSet: &flag.FlagSet{}, ParentCommand: parent}}
+	return &DaddyCommand{BaseCommand: &clicmd.BaseCommand{Cmdline: cmdline, FlagSet: &flag.FlagSet{}, Parent: parent}}
 }
 
 func (cmd *MeCommand) HandleArgs() error { return nil }
 func (cmd *MeCommand) Run() error        { return nil }
 
 func NewMeCommand(cmdline clicmd.Cmdline, parent *DaddyCommand) *MeCommand {
-	return &MeCommand{BaseCommand: &clicmd.BaseCommand{Cmdline: cmdline, FlagSet: &flag.FlagSet{}, ParentCommand: parent}}
+	return &MeCommand{BaseCommand: &clicmd.BaseCommand{Cmdline: cmdline, FlagSet: &flag.FlagSet{}, Parent: parent}}
 }
 
 func TestPappyDaddyMe(t *testing.T) {

--- a/cli/cmd/base.go
+++ b/cli/cmd/base.go
@@ -2,30 +2,26 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
-	"log/slog"
-	"reflect"
 	"strings"
 )
 
 type BaseCommand struct {
 	*flag.FlagSet
-	ParentCommand Command
-	Cmdline       Cmdline
-	Help          bool
+	Parent  Command
+	Cmdline Cmdline
+	Help    bool
 }
 
-func NewBaseCommand (name string, cmdline Cmdline, parent SuperCommand) *BaseCommand {
+func NewBaseCommand(name string, cmdline Cmdline, parent Command) *BaseCommand {
 	cmd := &BaseCommand{
 		Cmdline: cmdline,
-		ParentCommand: parent,
+		Parent:  parent,
 		FlagSet: flag.NewFlagSet(name, flag.ExitOnError),
 	}
 	cmd.FlagSet.BoolVar(&cmd.Help, "help", false, "give it to me")
-	
+
 	return cmd
 }
-
 
 func (cmd BaseCommand) Args() (Cmdline, bool) {
 	if !cmd.FlagSet.Parsed() {
@@ -34,7 +30,7 @@ func (cmd BaseCommand) Args() (Cmdline, bool) {
 	return cmd.FlagSet.Args(), true
 }
 
-func (cmd BaseCommand) CommandLine () Cmdline {
+func (cmd BaseCommand) CommandLine() Cmdline {
 	return cmd.Cmdline
 }
 
@@ -48,10 +44,10 @@ func (cmd BaseCommand) CommandArgs() ([]string, bool) {
 	}
 	var cmdArgs []string
 	var flag bool
-	if cmd.ParentCommand == nil {
+	if cmd.Parent == nil {
 		cmdArgs = []string{}
 	} else {
-		cmdArgs, flag = cmd.ParentCommand.CommandArgs()
+		cmdArgs, flag = cmd.Parent.CommandArgs()
 		if !flag {
 			return nil, flag
 		}
@@ -74,10 +70,11 @@ func (cmd BaseCommand) CommandString() (string, bool) {
 	return strings.Join(cmdArgs, " "), true
 }
 
-func (cmd BaseCommand) Log() {
-	stype := reflect.TypeOf(cmd).Name()
-	subArgs, _ := cmd.SubArgs()
-	slog.Debug(fmt.Sprintf("%s.Run()", stype), "args", subArgs)
+type NoSubcommandsError struct {}
+func (o NoSubcommandsError) Error() string { return "No Subcommands" }
+
+func (cmd BaseCommand) CreateSubCommand () (Command, error) {
+	return nil, &NoSubcommandsError{}
 }
 
 func (cmd BaseCommand) Parse() error {

--- a/cli/cmd/call.go
+++ b/cli/cmd/call.go
@@ -14,7 +14,7 @@ type CallCommand struct {
 	ScriptPath string   // flag
 }
 
-func NewCallCommand(cmdline Cmdline, parent SuperCommand) *CallCommand {
+func NewCallCommand(cmdline Cmdline, parent Command) *CallCommand {
 	// call command
 	name := "call"
 	cmd := CallCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -54,7 +54,7 @@ func (cmd *CallCommand) PrintUsage() {
 }
 
 func (cmd *CallCommand) Run() error {
-	cmd.Log()
+	slog.Debug("CallCommand.Run()", "args", cmd.Cmdline)
 
 	// Parse flags & get positional args
 	err := cmd.HandleArgs()

--- a/cli/cmd/cmdline.go
+++ b/cli/cmd/cmdline.go
@@ -28,21 +28,3 @@ func (o Cmdline) Command() string {
 func (o Cmdline) HasCommand() bool {
 	return len(o) > 0
 }
-
-type Command interface {
-	Args() (Cmdline, bool)
-	CommandLine() Cmdline
-	CommandName() string
-	CommandArgs() ([]string, bool)
-	CommandString() (string, bool)
-	HandleArgs() error
-	Parse() error
-	Run() error
-	SubArgs() (Cmdline, bool)
-	SubCommand() (string, bool)
-}
-
-type SuperCommand interface {
-	Command
-	CreateSubCommand() (Command, error)
-}

--- a/cli/cmd/command.go
+++ b/cli/cmd/command.go
@@ -1,0 +1,15 @@
+package cmd
+
+type Command interface {
+	Args() (Cmdline, bool)
+	CommandLine() Cmdline
+	CommandName() string
+	CommandArgs() ([]string, bool)
+	CommandString() (string, bool)
+	CreateSubCommand() (Command, error)
+	HandleArgs() error
+	Parse() error
+	Run() error
+	SubArgs() (Cmdline, bool)
+	SubCommand() (string, bool)
+}

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -13,7 +13,7 @@ type ConfigCommand struct {
 	*BaseCommand
 }
 
-func NewConfigCommand(cmdline Cmdline, parent SuperCommand) *ConfigCommand {
+func NewConfigCommand(cmdline Cmdline, parent Command) *ConfigCommand {
 	// config command
 	name := "config"
 	cmd := ConfigCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -95,7 +95,7 @@ func (cmd *ConfigCommand) Run() error {
 	return err
 }
 
-func RunConfig(cmdline Cmdline, parent SuperCommand) error {
+func RunConfig(cmdline Cmdline, parent Command) error {
 	slog.Debug("RunConfig()", "cmdline", cmdline, "parent", parent)
 	// Create the subcommand and run it
 	subCmd, err := createConfigSubCommand(cmdline, parent)
@@ -110,7 +110,7 @@ func RunConfig(cmdline Cmdline, parent SuperCommand) error {
 	return nil
 }
 
-func createConfigSubCommand(cmdline Cmdline, parent SuperCommand) (Command, error) {
+func createConfigSubCommand(cmdline Cmdline, parent Command) (Command, error) {
 	cmdName := cmdline.Command()
 	switch cmdName {
 	case "get":
@@ -136,7 +136,7 @@ type ConfigGetCommand struct {
 	Key string
 }
 
-func NewConfigGetCommand(cmdline Cmdline, parent SuperCommand) *ConfigGetCommand {
+func NewConfigGetCommand(cmdline Cmdline, parent Command) *ConfigGetCommand {
 	// config get command
 	name := "config.get"
 	cmd := &ConfigGetCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -216,7 +216,7 @@ type ConfigSetCommand struct {
 	Value string // arg 1
 }
 
-func NewConfigSetCommand(cmdline Cmdline, parent SuperCommand) *ConfigSetCommand {
+func NewConfigSetCommand(cmdline Cmdline, parent Command) *ConfigSetCommand {
 	// config set command
 	name := "config.set"
 	cmd := &ConfigSetCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -325,7 +325,7 @@ type ConfigShowCommand struct {
 	*BaseCommand
 }
 
-func NewConfigShowCommand(cmdline Cmdline, parent SuperCommand) *ConfigShowCommand {
+func NewConfigShowCommand(cmdline Cmdline, parent Command) *ConfigShowCommand {
 	// config show command
 	name := "config.set"
 	cmd := &ConfigShowCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -12,7 +12,7 @@ type GetCommand struct {
 	Key string // arg 0
 }
 
-func NewGetCommand(cmdline Cmdline, parent SuperCommand) *GetCommand {
+func NewGetCommand(cmdline Cmdline, parent Command) *GetCommand {
 	// get command
 	name := "get"
 	cmd := &GetCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/host.go
+++ b/cli/cmd/host.go
@@ -12,7 +12,7 @@ type HostCommand struct {
 	*BaseCommand
 }
 
-func NewHostCommand(cmdline Cmdline, parent SuperCommand) *HostCommand {
+func NewHostCommand(cmdline Cmdline, parent Command) *HostCommand {
 	// host command
 	name := "host"
 	cmd := &HostCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -98,7 +98,7 @@ func (cmd *HostCommand) Run() error {
 	return err
 }
 
-func RunHost(cmdline Cmdline, parent SuperCommand) error {
+func RunHost(cmdline Cmdline, parent Command) error {
 	slog.Debug("RunHost()", "cmdline", cmdline, "parent", parent)
 	// Create the subcommand and run it
 	subCmd, err := createHostSubCommand(cmdline, parent)
@@ -113,7 +113,7 @@ func RunHost(cmdline Cmdline, parent SuperCommand) error {
 	return nil
 }
 
-func createHostSubCommand(cmdline Cmdline, parent SuperCommand) (Command, error) {
+func createHostSubCommand(cmdline Cmdline, parent Command) (Command, error) {
 	cmdName := cmdline.Command()
 	switch cmdName {
 	case "init":
@@ -129,7 +129,7 @@ type HostInitCommand struct {
 	Uid int
 }
 
-func NewHostInitCommand(cmdline Cmdline, parent SuperCommand) *HostInitCommand {
+func NewHostInitCommand(cmdline Cmdline, parent Command) *HostInitCommand {
 	// host init command
 	name := "host.init"
 	cmd := &HostInitCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/host_test.go
+++ b/cli/cmd/host_test.go
@@ -88,7 +88,7 @@ func TestRunHost(t *testing.T) {
 	cmdName := "init"
 	cmdArgs := []string{}
 	cmdline := append(Cmdline{cmdName}, cmdArgs...)
-	parent := SuperCommand(nil)
+	parent := Command(nil)
 	err := RunHost(cmdline, parent)
 	assert.Nil(t, err)
 }

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -13,7 +13,7 @@ type InitCommand struct {
 	EtcdDomain string
 }
 
-func NewInitCommand(cmdline Cmdline, parent SuperCommand) *InitCommand {
+func NewInitCommand(cmdline Cmdline, parent Command) *InitCommand {
 	// init command
 	name := "init"
 	cmd := &InitCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/list.go
+++ b/cli/cmd/list.go
@@ -11,7 +11,7 @@ type ListCommand struct {
 	*BaseCommand
 }
 
-func NewListCommand(cmdline Cmdline, parent SuperCommand) *ListCommand {
+func NewListCommand(cmdline Cmdline, parent Command) *ListCommand {
 	// list command
 	name := "list"
 	cmd := &ListCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/main.go
+++ b/cli/cmd/main.go
@@ -14,7 +14,7 @@ type MainCommand struct {
 	*BaseCommand
 }
 
-func NewMainCommand(cmdline Cmdline, parent SuperCommand) *MainCommand {
+func NewMainCommand(cmdline Cmdline, parent Command) *MainCommand {
 	// main command
 	name := "dylt"
 	cmd := &MainCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/misc.go
+++ b/cli/cmd/misc.go
@@ -18,7 +18,7 @@ type MiscCommand struct {
 	*BaseCommand
 }
 
-func NewMiscCommand(cmdline Cmdline, parent SuperCommand) *MiscCommand {
+func NewMiscCommand(cmdline Cmdline, parent Command) *MiscCommand {
 	// misc command
 	name := "misc"
 	cmd := &MiscCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -101,7 +101,7 @@ func (cmd *MiscCommand) Run() error {
 	return err
 }
 
-func RunMisc(cmdline Cmdline, parent SuperCommand) error {
+func RunMisc(cmdline Cmdline, parent Command) error {
 	common.Logger.Debug("RunMisc()", "cmdline", cmdline, "parent", parent)
 	// create the subcommand and run it
 	subCmd, err := createMiscSubCommand(cmdline, parent)
@@ -116,7 +116,7 @@ func RunMisc(cmdline Cmdline, parent SuperCommand) error {
 	return nil
 }
 
-func createMiscSubCommand(cmdline Cmdline, parent SuperCommand) (Command, error) {
+func createMiscSubCommand(cmdline Cmdline, parent Command) (Command, error) {
 	cmdName := cmdline.Command()
 	switch cmdName {
 	case "create-two-node-cluster":
@@ -134,7 +134,7 @@ type CreateTwoNodeClusterCommand struct {
 	*BaseCommand
 }
 
-func NewCreateTwoNodeClusterCommand(cmdline Cmdline, parent SuperCommand) *CreateTwoNodeClusterCommand {
+func NewCreateTwoNodeClusterCommand(cmdline Cmdline, parent Command) *CreateTwoNodeClusterCommand {
 	// misc create-two-node-cluster command
 	name := "misc.create-two-node-cluster"
 	cmd := &CreateTwoNodeClusterCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -220,7 +220,7 @@ type GenEtcdRunScriptCommand struct {
 	*BaseCommand
 }
 
-func NewGenEtcdRunScriptCommand(cmdline Cmdline, parent SuperCommand) *GenEtcdRunScriptCommand {
+func NewGenEtcdRunScriptCommand(cmdline Cmdline, parent Command) *GenEtcdRunScriptCommand {
 	// misc gen-etcd-run-script command
 	name := "misc.gen-etcd-run-script"
 	cmd := &GenEtcdRunScriptCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -311,7 +311,7 @@ type LookupCommand struct {
 	Hostname string
 }
 
-func NewLookupCommand(cmdline Cmdline, parent SuperCommand) *LookupCommand {
+func NewLookupCommand(cmdline Cmdline, parent Command) *LookupCommand {
 	// misc lookup command
 	name := "misc.lookup"
 	cmd := &LookupCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/status.go
+++ b/cli/cmd/status.go
@@ -24,7 +24,7 @@ type StatusCommand struct {
 	*BaseCommand
 }
 
-func NewStatusCommand(cmdline Cmdline, parent SuperCommand) *StatusCommand {
+func NewStatusCommand(cmdline Cmdline, parent Command) *StatusCommand {
 	// status command
 	name := "status"
 	cmd := &StatusCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/test_utils.go
+++ b/cli/cmd/test_utils.go
@@ -25,7 +25,7 @@ func CheckRunCommandSuccessNoOutput(sCmdlineArgs string, t *testing.T) error {
 }
 
 func CreateAndTestCommand[U Command](t *testing.T,
-                                     fact func(Cmdline, SuperCommand) U,
+                                     fact func(Cmdline, Command) U,
                                      cmdName string,
                                      cmdFlags []string,
                                      cmdArgs []string,
@@ -76,7 +76,7 @@ func _TestSubCommandAndArgs(t *testing.T,
 }
 
 func _TestParentCommand(t *testing.T,
-                        cmd SuperCommand,
+                        cmd Command,
                         cmdName string,
                         cmdArgs Cmdline) {
 	err := cmd.HandleArgs()
@@ -97,7 +97,7 @@ func _TestParentCommand(t *testing.T,
 //    subArgs			arguments to pass to the subcommand
 //    targetCmdString	expected command string 
 func _TestSubcommandCreation[TCmd Command](t *testing.T,
-                                           cmd SuperCommand,
+                                           cmd Command,
                                            subName string,
                                            subCmdFlags []string,
                                            targetSubArgs []string,

--- a/cli/cmd/vm.go
+++ b/cli/cmd/vm.go
@@ -15,7 +15,7 @@ type VmCommand struct {
 	*BaseCommand
 }
 
-func NewVmCommand(cmdline Cmdline, parent SuperCommand) *VmCommand {
+func NewVmCommand(cmdline Cmdline, parent Command) *VmCommand {
 	// vm command
 	name := "vm"
 	cmd := &VmCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -120,7 +120,7 @@ func RunVm(cmdline Cmdline, parent *VmCommand) error {
 	return nil
 }
 
-func createVmSubCommand(cmdline Cmdline, parent SuperCommand) (Command, error) {
+func createVmSubCommand(cmdline Cmdline, parent Command) (Command, error) {
 	subCmd := cmdline.Command()
 	switch subCmd {
 	case "add":
@@ -146,7 +146,7 @@ type VmAddCommand struct {
 	Fqdn string // arg 1
 }
 
-func NewVmAddCommand(cmdline Cmdline, parent SuperCommand) *VmAddCommand {
+func NewVmAddCommand(cmdline Cmdline, parent Command) *VmAddCommand {
 	// vm add command
 	name := "vm.add"
 	cmd := &VmAddCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -233,7 +233,7 @@ type VmAllCommand struct {
 	*BaseCommand
 }
 
-func NewVmAllCommand(cmdline Cmdline, parent SuperCommand) *VmAllCommand {
+func NewVmAllCommand(cmdline Cmdline, parent Command) *VmAllCommand {
 	// vm all command
 	name := "vm.all"
 	cmd := &VmAllCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -325,7 +325,7 @@ type VmDelCommand struct {
 	Name string // arg 0
 }
 
-func NewVmDelCommand(cmdline Cmdline, parent SuperCommand) *VmDelCommand {
+func NewVmDelCommand(cmdline Cmdline, parent Command) *VmDelCommand {
 	// vm del command
 	name := "vm.del"
 	cmd := &VmDelCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -419,7 +419,7 @@ type VmGetCommand struct {
 	Name string // arg 0
 }
 
-func NewVmGetCommand(cmdline Cmdline, parent SuperCommand) *VmGetCommand {
+func NewVmGetCommand(cmdline Cmdline, parent Command) *VmGetCommand {
 	// vm get command
 	name := "vm.get"
 	cmd := &VmGetCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -514,7 +514,7 @@ type VmListCommand struct {
 	*BaseCommand
 }
 
-func NewVmListCommand(cmdline Cmdline, parent SuperCommand) *VmListCommand {
+func NewVmListCommand(cmdline Cmdline, parent Command) *VmListCommand {
 	// vm list command
 	name := "vm.list"
 	cmd := &VmListCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -610,7 +610,7 @@ type VmSetCommand struct {
 	Value string // arg 2
 }
 
-func NewVmSetCommand(cmdline Cmdline, parent SuperCommand) *VmSetCommand {
+func NewVmSetCommand(cmdline Cmdline, parent Command) *VmSetCommand {
 	// vm set command
 	name := "vm.set"
 	cmd := &VmSetCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}

--- a/cli/cmd/watch.go
+++ b/cli/cmd/watch.go
@@ -15,7 +15,7 @@ type WatchCommand struct {
 	*BaseCommand
 }
 
-func NewWatchCommand(cmdline Cmdline, parent SuperCommand) *WatchCommand {
+func NewWatchCommand(cmdline Cmdline, parent Command) *WatchCommand {
 	// watch command
 	name := "watch"
 	cmd := &WatchCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -100,7 +100,7 @@ func (cmd *WatchCommand) Run() error {
 	return err
 }
 
-func RunWatch(cmdline Cmdline, parent SuperCommand) error {
+func RunWatch(cmdline Cmdline, parent Command) error {
 	slog.Debug("RunWatch()", "cmdline", cmdline, "parent", parent)
 	// Create the subcommand and run it
 	subCmd, err := createWatchSubCommand(cmdline, parent)
@@ -115,7 +115,7 @@ func RunWatch(cmdline Cmdline, parent SuperCommand) error {
 	return nil
 }
 
-func createWatchSubCommand(cmdline Cmdline, parent SuperCommand) (Command, error) {
+func createWatchSubCommand(cmdline Cmdline, parent Command) (Command, error) {
 	cmdName := cmdline.Command()
 	switch cmdName {
 	case "script":
@@ -136,7 +136,7 @@ type WatchScriptCommand struct {
 	TargetPath string // arg 1
 }
 
-func NewWatchScriptCommand(cmdline Cmdline, parent SuperCommand) *WatchScriptCommand {
+func NewWatchScriptCommand(cmdline Cmdline, parent Command) *WatchScriptCommand {
 	// watch script command
 	name := "watch.script"
 	cmd := &WatchScriptCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}
@@ -210,7 +210,7 @@ type WatchSvcCommand struct {
 	Name string
 }
 
-func NewWatchSvcCommand(cmdline Cmdline, parent SuperCommand) *WatchSvcCommand {
+func NewWatchSvcCommand(cmdline Cmdline, parent Command) *WatchSvcCommand {
 	// watch svc command
 	name := "watch.svc"
 	cmd := &WatchSvcCommand{BaseCommand: NewBaseCommand(name, cmdline, parent)}


### PR DESCRIPTION
…to new command.go file. Created simple NoSubCommandsError custom error. SuperCommand is gone now.