### PR TITLE
Standardize release asset naming to Go GOOS-GOARCH convention

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,14 +27,8 @@ builds:
 
 archives:
   - formats: ['tar.gz']
-    # this name template makes the OS and Arch compatible with the results of `uname`.
-    name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # lowercase dash-separated naming matches Go GOOS-GOARCH convention
+    name_template: "{{ .ProjectName }}_{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     # use zip for windows archives
     format_overrides:
       - goos: windows


### PR DESCRIPTION
Replace multi-line name_template (OS_arch with title-case OS and x86_64/i386) with lowercase dash-separated format matching Go GOOS-GOARCH convention.

Old: dylt_Darwin_x86_64.tar.gz, dylt_Linux_arm64.tar.gz, etc.
New: dylt_darwin-amd64.tar.gz, dylt_linux-arm64.tar.gz, etc.