### PR TITLE
Add extended build group for Windows, fix ARM32 goarch

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - v*
+  workflow_dispatch:
+    inputs:
+      include_extended:
+        description: 'Build Windows releases too'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -26,7 +32,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean ${{ github.event.inputs.include_extended == 'true' && '--id=primary --id=extended' || '--id=primary' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPRIVATE: github.com/dylt-dev

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,14 +16,30 @@ before:
     - go generate ./...
 
 builds:
-  - env:
+  - id: primary
+    env:
       - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - "386"
     goarm:
       - 6
       - 7
     goos:
       - darwin
       - linux
+
+  - id: extended
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+    goos:
+      - windows
 
 archives:
   - formats: ['tar.gz']


### PR DESCRIPTION
### Changes

- **builds**: Split into `primary` (darwin+linux) and `extended` (windows) groups with separate IDs
- **goarch**: Added explicit list including `arm` — goreleaser v2 defaults no longer include it, so ARM32 builds (`linux-armv6`/`linux-armv7`) were silently not being produced
- **workflow**: Added `workflow_dispatch` trigger with `include_extended` checkbox. Tag pushes and unticked runs build `primary` only. Ticked runs include Windows.
- **daylight.sh**: `dylt-legacy-platform` now maps `windows-amd64` → `Windows_x86_64` and `windows-arm64` → `Windows_arm64`

See `/root/daylight-refactor/dylt-extended-platforms-plan.md` for full plan.