### PR TITLE
fix: merge build groups, remove --id flag (not in goreleaser v2)

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:
-    inputs:
-      include_extended:
-        description: 'Build Windows releases too'
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -32,7 +26,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean ${{ github.event.inputs.include_extended == 'true' && '--id=primary --id=extended' || '--id=primary' }}
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPRIVATE: github.com/dylt-dev

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,8 +16,7 @@ before:
     - go generate ./...
 
 builds:
-  - id: primary
-    env:
+  - env:
       - CGO_ENABLED=0
     goarch:
       - amd64
@@ -30,16 +29,13 @@ builds:
     goos:
       - darwin
       - linux
-
-  - id: extended
-    env:
-      - CGO_ENABLED=0
-    goarch:
-      - amd64
-      - arm64
-      - "386"
-    goos:
       - windows
+    # skip unsupported GOOS/GOARCH combos
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
 
 archives:
   - formats: ['tar.gz']


### PR DESCRIPTION
### Problem
The `--id` flag does not exist in goreleaser v2 (which is what `latest` resolves to). The previous PR (#118) introduced split build groups (`primary`/`extended`) and used `--id` to select them, but goreleaser v2.16.0 rejects this with `unknown flag: --id`.

### Fix
- Merge all builds (darwin, linux, windows) into a single group
- Remove `workflow_dispatch` / `include_extended` checkbox (no longer needed)
- Explicitly ignore unsupported GOOS/GOARCH combos (`darwin/386`, `darwin/arm`) to prevent build failures
- Simplify `args` to just `release --clean`

All platforms (darwin amd64/arm64, linux amd64/arm64/arm/386, windows amd64/arm64/386) will now be built on every tag push.