### PR TITLE
Add install-sunbeam.sh, README, and add-to-bashrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# dylt
+
+CLI tool for creating and managing dylt clusters.
+
+## Install
+
+- [install sunbeam.sh](install-sunbeam.sh) — Bootstrap sunbeam.sh for development tasks
+- [How-to release nightly](Howto-release-nightly.md) — Build and publish a nightly release
+
+## Development
+
+See [How-commands-work.md](How-commands-work.md) for the command architecture.

--- a/install-sunbeam.sh
+++ b/install-sunbeam.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# install-sunbeam.sh — Bootstrap sunbeam.sh
+#
+# sunbeam.sh is a utility script for dylt development tasks.
+# It lives at ~/.local/bin/sunbeam.sh and provides commands for
+# nightly releases, tagging, and other dev workflows.
+#
+# ## Usage
+#
+#   curl -fsSL https://raw.githubusercontent.com/dylt-dev/dylt/main/install-sunbeam.sh | bash
+#
+# ## Ubuntu / Debian
+#
+#   curl -fsSL https://raw.githubusercontent.com/dylt-dev/dylt/main/install-sunbeam.sh | bash
+#
+# ## macOS
+#
+#   curl -fsSL https://raw.githubusercontent.com/dylt-dev/dylt/main/install-sunbeam.sh | bash
+#
+# ## Windows (Git Bash / WSL)
+#
+#   curl -fsSL https://raw.githubusercontent.com/dylt-dev/dylt/main/install-sunbeam.sh | bash
+#
+# ## What it does
+#
+#   1. Downloads sunbeam.sh to ~/.local/bin/sunbeam.sh
+#   2. Makes it executable
+#
+# ## After install
+#
+#   Run `sunbeam add-to-bashrc` to add a `sunbeam()` shell function
+#   to ~/.bashrc so you can type `sunbeam` from anywhere.
+#
+#   Then restart your shell or run: source ~/.bashrc
+
+
+main ()
+{
+    local installPath="${1:-$HOME/.local/bin/sunbeam.sh}"
+
+    printf 'Installing sunbeam.sh to %s ...\n' "$installPath"
+    mkdir -p "$(dirname "$installPath")" || { printf 'Failed to create directory\n' >&2; exit 1; }
+
+    curl -fsSL -o "$installPath" https://raw.githubusercontent.com/dylt-dev/dylt/main/sunbeam.sh || {
+        printf 'Failed to download sunbeam.sh\n' >&2
+        exit 1
+    }
+
+    chmod 755 "$installPath" || { printf 'Failed to chmod\n' >&2; exit 1; }
+
+    printf '\nDone — installed to %s\n' "$installPath"
+    printf 'Next step: run  %s add-to-bashrc  to add the `sunbeam` shell function\n' "$installPath"
+    printf 'Then:   source ~/.bashrc\n'
+    printf 'Then:   sunbeam --help\n'
+}
+
+
+main "$@"

--- a/sunbeam.sh
+++ b/sunbeam.sh
@@ -204,12 +204,39 @@ install-build-dylt-svc ()
 }
 
 
+add-to-bashrc ()
+{
+    local bashrc="$HOME/.bashrc"
+    local funcName='sunbeam'
+    local sunbeamPath="$HOME/.local/bin/sunbeam.sh"
+
+    if grep -q "^${funcName}()" "$bashrc" 2>/dev/null; then
+        printf '`%s` function already exists in %s — nothing to do\n' "$funcName" "$bashrc"
+        return 0
+    fi
+
+    cat >> "$bashrc" << EOF
+
+# added by opencode in loyal service to master
+$funcName()
+{
+    $sunbeamPath "\$@"
+}
+EOF
+
+    printf 'Added `%s` function to %s\n' "$funcName" "$bashrc"
+    printf 'Restart your shell or run: source %s\n' "$bashrc"
+    printf 'Then type: %s --help\n' "$funcName"
+}
+
+
 main ()
 {
     if (($# >= 1)); then
         local cmd=$1
         shift
         case "$cmd" in
+            add-to-bashrc)                            add-to-bashrc "$@";;
             gen-nightly-tagname)                      gen-nightly-tagname "$@";;
             gen-nightly-timestamp)                    gen-nightly-timestamp "$@";;
             git-do-nightly-release)                   git-do-nightly-release "$@";;


### PR DESCRIPTION
Introduces a bootstrapping and shell-integration workflow for sunbeam.sh.

- **install-sunbeam.sh** — self-documenting shell script for first-time install to `~/.local/bin/sunbeam.sh`
- **README.md** — project README with `install sunbeam.sh` link
- **sunbeam.sh** — new `add-to-bashrc` function that appends a `sunbeam()` shell function to \~/.bashrc so users can type `sunbeam` from anywhere

Closes #123