### PR TITLE
Two-tier release matrix with nightly/full configs + tag format consistency

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - v*
+      - 'v*-nightly-*'
 
 permissions:
   contents: write

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -19,7 +19,8 @@ jobs:
           echo "VERSION=${TAG%%-*}" >> "$GITHUB_ENV"
       - name: Create nightly tag
         run: |
-          DATE=$(date +'%Y%m%d')
+          REPO="${{ github.repository }}"
+          DATE=$(date +'%Y-%m-%d')
           TIMESTAMP=$(date +'%H%M%S')
 
           LABEL="${{ inputs.label || '' }}"
@@ -27,10 +28,15 @@ jobs:
           LABEL="${LABEL//[^a-zA-Z0-9._-]/}"
 
           if [ -n "$LABEL" ]; then
-            TAG="v${{ env.VERSION }}-nightly-${DATE}-${LABEL}-${TIMESTAMP}"
+            TAG="v${{ env.VERSION }}-nightly-${DATE}-${LABEL}"
+            if curl -sf -o /dev/null "https://api.github.com/repos/${REPO}/git/ref/tags/${TAG}"; then
+              TAG="${TAG}-${TIMESTAMP}"
+            fi
           else
             TAG="v${{ env.VERSION }}-nightly-${DATE}"
-            git tag "$TAG" 2>/dev/null || TAG="${TAG}-${TIMESTAMP}"
+            if curl -sf -o /dev/null "https://api.github.com/repos/${REPO}/git/ref/tags/${TAG}"; then
+              TAG="${TAG}-${TIMESTAMP}"
+            fi
           fi
 
           git tag "$TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,12 @@ on:
 
 jobs:
   goreleaser:
+    if: ${{ !contains(github.ref_name, '-nightly-') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: stable
@@ -16,6 +19,7 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean --config=.goreleaser.full.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOPRIVATE: github.com/dylt-dev

--- a/.goreleaser.full.yaml
+++ b/.goreleaser.full.yaml
@@ -13,10 +13,23 @@ builds:
       - CGO_ENABLED=0
     goarch:
       - amd64
+      - arm64
+      - arm
+      - "386"
+    goarm:
+      - 6
+      - 7
     goos:
       - darwin
       - linux
       - windows
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
 
 archives:
   - formats: ['tar.gz']

--- a/tools/test-146-release-matrix-tier.sh
+++ b/tools/test-146-release-matrix-tier.sh
@@ -1,0 +1,190 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+source "$SCRIPT_DIR/test-utils.sh" || exit 1
+REPO_DIR=$(dirname "$SCRIPT_DIR")
+
+
+#-------------------------------------------------------------------------------
+#
+# run-tests()
+#
+run-tests()
+{
+    local tests=(
+        test-goreleaser-yaml-core
+        test-goreleaser-full-yaml-exists
+        test-goreleaser-full-yaml-content
+        test-workflow-goreleaser-trigger
+        test-workflow-release-config
+        test-workflow-nightly-format
+        test-workflow-nightly-tag-format
+    )
+    local total=0 passed=0 failed=0
+    for t in "${tests[@]}"; do
+        printf '=== %s ===\n' "$t"
+        (( total++ ))
+        if "$t"; then
+            (( passed++ ))
+        else
+            (( failed++ ))
+        fi
+    done
+    printf '\n%d total, %d passed, %d failed\n' "$total" "$passed" "$failed"
+    return "$failed"
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-goreleaser-yaml-core()
+#
+# Verify .goreleaser.yaml builds only amd64 across darwin/linux/windows
+#
+test-goreleaser-yaml-core()
+{
+    local f="$REPO_DIR/.goreleaser.yaml"
+    [[ -f "$f" ]] || { printf '  FAIL: %s not found\n' "$f"; return 1; }
+
+    grep -qF '  - amd64' "$f" || { printf '  FAIL: missing amd64 goarch\n'; return 1; }
+    grep -qF '  - darwin' "$f" || { printf '  FAIL: missing darwin goos\n'; return 1; }
+    grep -qF '  - linux' "$f"  || { printf '  FAIL: missing linux goos\n';  return 1; }
+    grep -qF '  - windows' "$f" || { printf '  FAIL: missing windows goos\n'; return 1; }
+
+    grep -qF 'arm64'  "$f" && { printf '  FAIL: arm64 should not be in core config\n'; return 1; }
+    grep -qF '  - arm' "$f" && { printf '  FAIL: arm should not be in core config\n'; return 1; }
+    grep -qF '  - "386"' "$f" && { printf '  FAIL: 386 should not be in core config\n'; return 1; }
+    grep -qF 'goarm:' "$f" && { printf '  FAIL: goarm should not be in core config\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-goreleaser-full-yaml-exists()
+#
+# Verify .goreleaser.full.yaml is present
+#
+test-goreleaser-full-yaml-exists()
+{
+    [[ -f "$REPO_DIR/.goreleaser.full.yaml" ]] || {
+        printf '  FAIL: .goreleaser.full.yaml not found\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-goreleaser-full-yaml-content()
+#
+# Verify .goreleaser.full.yaml has full matrix + windows/arm ignore
+#
+test-goreleaser-full-yaml-content()
+{
+    local f="$REPO_DIR/.goreleaser.full.yaml"
+    grep -qF 'arm64'      "$f" || { printf '  FAIL: missing arm64\n'; return 1; }
+    grep -qF '  - arm'    "$f" || { printf '  FAIL: missing arm\n'; return 1; }
+    grep -qF '  - "386"'  "$f" || { printf '  FAIL: missing 386\n'; return 1; }
+    grep -qF 'goarm:'     "$f" || { printf '  FAIL: missing goarm\n'; return 1; }
+    grep -qF '  - 6'      "$f" || { printf '  FAIL: missing goarm 6\n'; return 1; }
+    grep -qF '  - 7'      "$f" || { printf '  FAIL: missing goarm 7\n'; return 1; }
+    grep -qF 'windows'    "$f" || { printf '  FAIL: missing windows/arm ignore\n'; return 1; }
+    grep -qF '  goarch: arm' "$f" || { printf '  FAIL: missing arm in ignore\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-workflow-goreleaser-trigger()
+#
+# Verify goreleaser.yaml workflow only triggers on v*-nightly-* tags
+# and uses the default core config (no --config flag)
+#
+test-workflow-goreleaser-trigger()
+{
+    local f="$REPO_DIR/.github/workflows/goreleaser.yaml"
+    [[ -f "$f" ]] || { printf '  FAIL: %s not found\n' "$f"; return 1; }
+    grep -qF "v*-nightly-*" "$f" || { printf '  FAIL: missing v*-nightly-* tag pattern\n'; return 1; }
+    grep -qF "args: release --clean" "$f" || { printf '  FAIL: missing goreleaser release\n'; return 1; }
+    grep -qF -- '--config=' "$f" && { printf '  FAIL: should not use --config (defaults to core)\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-workflow-release-config()
+#
+# Verify release.yml has -nightly- skip condition and --config flag
+#
+test-workflow-release-config()
+{
+    local f="$REPO_DIR/.github/workflows/release.yml"
+    [[ -f "$f" ]] || { printf '  FAIL: %s not found\n' "$f"; return 1; }
+    grep -qF "contains(github.ref_name, '-nightly-')" "$f" || {
+        printf '  FAIL: missing nightly skip condition\n'; return 1; }
+    grep -qF -- '--config=.goreleaser.full.yaml' "$f" || {
+        printf '  FAIL: missing --config flag\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-workflow-nightly-format()
+#
+# Verify nightly-release.yml uses YYYY-MM-DD date format and curl-based dedup
+#
+test-workflow-nightly-format()
+{
+    local f="$REPO_DIR/.github/workflows/nightly-release.yml"
+    [[ -f "$f" ]] || { printf '  FAIL: %s not found\n' "$f"; return 1; }
+    grep -qF '%Y-%m-%d' "$f" || { printf '  FAIL: missing YYYY-MM-DD date format\n'; return 1; }
+    grep -qF 'git/ref/tags' "$f" || { printf '  FAIL: missing curl-based tag existence check\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# test-workflow-nightly-tag-format()
+#
+# Verify nightly-release.yml builds tags matching v<ver>-nightly-<date>[-label]
+#
+test-workflow-nightly-tag-format()
+{
+    local f="$REPO_DIR/.github/workflows/nightly-release.yml"
+    grep -qF 'TAG="v${{' "$f" || { printf '  FAIL: missing version prefix in tag\n'; return 1; }
+    grep -qF 'nightly-${DATE}' "$f" || { printf '  FAIL: missing nightly-DATE in tag template\n'; return 1; }
+    printf '  PASS\n'
+}
+
+
+#-------------------------------------------------------------------------------
+#
+# main()
+#
+main()
+{
+    if (( $# >= 1 )); then
+        local cmd=$1; shift
+        case "$cmd" in
+            run-tests)                              run-tests;;
+            test-goreleaser-yaml-core)               test-goreleaser-yaml-core;;
+            test-goreleaser-full-yaml-exists)         test-goreleaser-full-yaml-exists;;
+            test-goreleaser-full-yaml-content)        test-goreleaser-full-yaml-content;;
+            test-workflow-goreleaser-trigger)         test-workflow-goreleaser-trigger;;
+            test-workflow-release-config)             test-workflow-release-config;;
+            test-workflow-nightly-format)             test-workflow-nightly-format;;
+            test-workflow-nightly-tag-format)         test-workflow-nightly-tag-format;;
+            *)                                        printf 'Unknown test: %s\n' "$cmd" >&2; exit 1;;
+        esac
+    else
+        run-tests
+    fi
+}
+
+if ! (return 0 2>/dev/null); then
+    main "$@"
+fi


### PR DESCRIPTION
Split releases into two tiers:

| Tag | Workflow | Config | Platforms |
|---|---|---|---|
| `v*-nightly-*` | goreleaser.yaml | `.goreleaser.yaml` (default) | linux/amd64, darwin/amd64, windows/amd64 |
| `v*$!contains(-nightly-)` | release.yml | `.goreleaser.full.yaml` | Full matrix (incl. arm, 386) |

## Changes
- `.goreleaser.yaml` — reduced to core 3 amd64 platforms
- `.goreleaser.full.yaml` (new) — full matrix from current config plus `windows/arm` ignore fix
- `goreleaser.yaml` workflow — tag filter `v*-nightly-*`, no `--config` (default = core)
- `release.yml` — conditional skip for nightly tags + `--config=.goreleaser.full.yaml`
- `nightly-release.yml` — aligned with daylight: date dashes (`YYYY-MM-DD`), `nightly-` separator, dedup via curl on tag conflict

Closes #146