### PR TITLE
Add branch analysis functions to sunbeam.sh

### DIFF
--- a/sunbeam.sh
+++ b/sunbeam.sh
@@ -509,6 +509,137 @@ download-github-utils ()
     safe-curl "https://raw.githubusercontent.com/daylight-public/daylight/main/github-utils.sh"
 }
 
+#-------------------------------------------------------------------------------
+
+# gh-branch-clean()
+
+# Delete remote branches that are fully merged into a base branch.
+# Uses gh-branch-merged to find candidates, then prompts for confirmation.
+# Accepts an optional base branch (default: main).
+
+gh-branch-clean ()
+{
+    (( $# <= 1 )) || { printf 'Usage: gh-branch-clean [base]
+' >&2; return 1; }
+    local base=${1:-main}
+    local merged
+    merged=$(gh-branch-merged "$base") || return
+    if [[ -z "$merged" ]]; then
+        printf 'No merged branches found.
+'
+        return 0
+    fi
+    local reply
+    printf 'Branches fully merged into %s:
+' "$base"
+    printf '%s
+' "$merged" | while IFS= read -r branch; do
+        read -r -n1 -p "Delete $branch? (y/N) " reply
+        printf '
+'
+        if [[ $reply == [yY] ]]; then
+            git push origin --delete "$branch" || {
+                printf '  Failed to delete %s
+' "$branch" >&2
+            }
+        fi
+    done
+}
+
+
+#-------------------------------------------------------------------------------
+
+# gh-branch-compare()
+
+# Show ahead count and diff stat for a branch against a base.
+# Uses gh api to get the ahead count and git diff for the real content diff.
+# The ahead count alone can be misleading after squash merges — git diff
+# is the definitive check.
+
+gh-branch-compare ()
+{
+    (( $# >= 1 && $# <= 2 )) || { printf 'Usage: gh-branch-compare $branch [base]
+' >&2; return 1; }
+    local branch=$1 base=${2:-main}
+
+    # gh compares the commit histories. ahead_by counts commits on the
+    # branch not reachable from base. After a squash merge, the branch's
+    # commits aren't in base's history, so ahead_by won't be 0 even
+    # though the content is fully merged.
+    local ahead
+    ahead=$(gh api "repos/:owner/:repo/compare/$base...$branch" --jq '.ahead_by') || return
+
+    # git diff base...branch --stat checks the actual content difference
+    # between the two trees ignoring commit history. Zero lines of diff
+    # means the content is fully merged regardless of how it was merged.
+    local diffStat
+    diffStat=$(git diff "$base...$branch" --stat 2>/dev/null) || true
+
+    printf 'Branch: %s (base: %s)
+' "$branch" "$base"
+    printf '  Ahead by: %d commits
+' "$ahead"
+    if [[ -n "$diffStat" ]]; then
+        printf '  Diff:
+'
+        printf '%s
+' "$diffStat" | sed 's/^/    /'
+    else
+        printf '  Diff: (none — fully merged)
+'
+    fi
+}
+
+
+#-------------------------------------------------------------------------------
+
+# gh-branch-list()
+
+# List all remote branches for the current repo.
+
+gh-branch-list ()
+{
+    (( $# == 0 )) || { printf 'Usage: gh-branch-list
+' >&2; return 1; }
+
+    # gh api returns JSON with branch metadata. We extract just the names.
+    # The --paginate flag handles repos with many branches.
+    gh api repos/:owner/:repo/branches --paginate --jq '.[].name'
+}
+
+
+#-------------------------------------------------------------------------------
+
+# gh-branch-merged()
+
+# List branches with zero content diff against a base branch.
+# These branches are safe to delete — their content is already merged,
+# regardless of whether a squash or merge commit was used.
+
+gh-branch-merged ()
+{
+    (( $# <= 1 )) || { printf 'Usage: gh-branch-merged [base]
+' >&2; return 1; }
+    local base=${1:-main}
+    local branches
+
+    branches=$(gh-branch-list) || return
+
+    # For each branch, check whether git diff shows any file changes.
+    # Zero lines of diff output means the content is identical — the
+    # branch is fully merged and safe to delete.
+    printf '%s
+' "$branches" | while IFS= read -r branch; do
+        [[ "$branch" == "$base" ]] && continue
+        local diffCount
+        diffCount=$(git diff "$base...$branch" --stat 2>/dev/null | wc -l) || true
+        if (( diffCount == 0 )); then
+            printf '%s
+' "$branch"
+        fi
+    done
+}
+
 
 
 
@@ -1190,6 +1321,10 @@ main ()
             download-dylt-batch)                      download-dylt-batch "$@";;
             download-daylight)                        download-daylight "$@";;
             download-daylight-batch)                  download-daylight-batch "$@";;
+            gh-branch-clean)                          gh-branch-clean "$@";;
+            gh-branch-compare)                        gh-branch-compare "$@";;
+            gh-branch-list)                           gh-branch-list "$@";;
+            gh-branch-merged)                         gh-branch-merged "$@";;
             git-download-latest-daylightsh)           git-download-latest-daylightsh "$@";;
             git-get-latest-release-spec)              git-get-latest-release-spec "$@";;
             git-get-latest-release-tag)               git-get-latest-release-tag "$@";;

--- a/tools/test-160-branch-analysis.sh
+++ b/tools/test-160-branch-analysis.sh
@@ -1,0 +1,115 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$BASH_SOURCE")")
+SUNBEAM_SH="$SCRIPT_DIR/../sunbeam.sh"
+[[ -f "$SUNBEAM_SH" ]] || { printf 'Cannot find sunbeam.sh\n' >&2; exit 1; }
+
+source "$SCRIPT_DIR/test-utils.sh" || exit 1
+source "$SUNBEAM_SH" || { printf 'Failed to source sunbeam.sh\n' >&2; exit 1; }
+
+
+test-gh-branch-list-usage()
+{
+    gh-branch-list a 2>/dev/null && {
+        printf '  FAIL (gh-branch-list-usage): expected failure with args\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-gh-branch-compare-usage()
+{
+    gh-branch-compare 2>/dev/null && {
+        printf '  FAIL (gh-branch-compare-usage): expected failure with no args\n'
+        return 1
+    }
+    gh-branch-compare a b c 2>/dev/null && {
+        printf '  FAIL (gh-branch-compare-usage): expected failure with 3 args\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-gh-branch-merged-usage()
+{
+    gh-branch-merged a b 2>/dev/null && {
+        printf '  FAIL (gh-branch-merged-usage): expected failure with 2 args\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-gh-branch-clean-usage()
+{
+    gh-branch-clean a b 2>/dev/null && {
+        printf '  FAIL (gh-branch-clean-usage): expected failure with 2 args\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+test-gh-branch-list-runs()
+{
+    command -v gh >/dev/null 2>&1 || {
+        printf '  SKIP (gh-branch-list-runs): gh not installed\n'
+        return 0
+    }
+
+    local out
+    out=$(gh-branch-list 2>/dev/null) || {
+        printf '  FAIL (gh-branch-list-runs): returned non-zero\n'
+        return 1
+    }
+    printf '%s' "$out" | grep -q 'main' || {
+        printf '  FAIL (gh-branch-list-runs): "main" not in branch list\n'
+        return 1
+    }
+    printf '  PASS\n'
+}
+
+
+run-tests()
+{
+    local tests=(
+        test-gh-branch-list-usage
+        test-gh-branch-compare-usage
+        test-gh-branch-merged-usage
+        test-gh-branch-clean-usage
+        test-gh-branch-list-runs
+    )
+    local total=0 passed=0 failed=0
+    for t in "${tests[@]}"; do
+        printf '=== %s ===\n' "$t"
+        (( total++ ))
+        if "$t"; then
+            (( passed++ ))
+        else
+            (( failed++ ))
+        fi
+    done
+    printf '\n%d total, %d passed, %d failed\n' "$total" "$passed" "$failed"
+    return "$failed"
+}
+
+
+main()
+{
+    case ${1:-all} in
+        test-gh-branch-list-usage)     test-gh-branch-list-usage ;;
+        test-gh-branch-compare-usage)  test-gh-branch-compare-usage ;;
+        test-gh-branch-merged-usage)   test-gh-branch-merged-usage ;;
+        test-gh-branch-clean-usage)    test-gh-branch-clean-usage ;;
+        test-gh-branch-list-runs)      test-gh-branch-list-runs ;;
+        all)                           run-tests ;;
+        *)                             printf 'Unknown test: %s\n' "$1" >&2; exit 1 ;;
+    esac
+}
+
+
+if ! (return 0 2>/dev/null); then
+    main "$@"
+fi


### PR DESCRIPTION
Closes #160

### Changes

- `sunbeam.sh` — four new functions: `gh-branch-list`, `gh-branch-compare`, `gh-branch-merged`, `gh-branch-clean`
- `sunbeam.sh` — case dispatch entries for all four
- `tools/test-160-branch-analysis.sh` — 5 tests, all passing

### Design notes

- All functions use `gh api`, `jq`, and `git` — no new dependencies
- `gh-branch-compare` shows both `ahead_by` (from gh API) and a full `git diff --stat`
  The comment explains why ahead_by alone is unreliable after squash merges
- `gh-branch-merged` uses `git diff base...branch --stat` as the definitive "is it merged?" check
- `gh-branch-clean` prompts for each branch before deleting